### PR TITLE
Add noswallow wrapper binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,12 @@ include config.mk
 
 SRC = drw.c dwm.c util.c
 OBJ = ${SRC:.c=.o}
+NS_SRC = noswallow.c
+NS_OBJ = ${NS_SRC:.c=.o}
+PREFIX = /usr
+MANPREFIX = /usr/share/man
 
-all: options dwm
+all: options dwm noswallow
 
 options:
 	@echo dwm build options:
@@ -25,8 +29,11 @@ config.h:
 dwm: ${OBJ}
 	${CC} -o $@ ${OBJ} ${LDFLAGS}
 
+noswallow: ${NS_OBJ}
+	${CC} -o $@ ${NS_OBJ}
+
 clean:
-	rm -f dwm ${OBJ} dwm-${VERSION}.tar.gz
+	rm -f dwm ${OBJ} dwm-${VERSION}.tar.gz noswallow ${NS_OBJ}
 
 dist: clean
 	mkdir -p dwm-${VERSION}
@@ -39,13 +46,17 @@ dist: clean
 install: all
 	mkdir -p ${DESTDIR}${PREFIX}/bin
 	cp -f dwm ${DESTDIR}${PREFIX}/bin
+	cp -f noswallow ${DESTDIR}${PREFIX}/bin
 	chmod 755 ${DESTDIR}${PREFIX}/bin/dwm
+	chmod 755 ${DESTDIR}${PREFIX}/bin/noswallow
+	echo ${DESTDIR}${MANPREFIX}/man1
 	mkdir -p ${DESTDIR}${MANPREFIX}/man1
 	sed "s/VERSION/${VERSION}/g" < dwm.1 > ${DESTDIR}${MANPREFIX}/man1/dwm.1
 	chmod 644 ${DESTDIR}${MANPREFIX}/man1/dwm.1
 
 uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/dwm\
-		${DESTDIR}${MANPREFIX}/man1/dwm.1
+		${DESTDIR}${MANPREFIX}/man1/dwm.1\
+		${DESTDIR}${PREFIX}/bin/noswallow
 
 .PHONY: all options clean dist install uninstall

--- a/dwm.c
+++ b/dwm.c
@@ -258,6 +258,7 @@ static void zoom(const Arg *arg);
 
 static pid_t getparentprocess(pid_t p);
 static int isdescprocess(pid_t p, pid_t c);
+static int isdescnoswallowprocess(pid_t c);
 static Client *swallowingclient(Window w);
 static Client *termforwin(const Client *c);
 static pid_t winpid(Window w);
@@ -356,6 +357,7 @@ applyrules(Client *c)
 	if (ch.res_name)
 		XFree(ch.res_name);
 	c->tags = c->tags & TAGMASK ? c->tags & TAGMASK : c->mon->tagset[c->mon->seltags];
+	c->noswallow = c->noswallow || isdescnoswallowprocess(c->pid);
 }
 
 int
@@ -2611,6 +2613,29 @@ isdescprocess(pid_t p, pid_t c)
 		c = getparentprocess(c);
 
 	return (int)c;
+}
+
+int
+isdescnoswallowprocess(pid_t c)
+{
+	pid_t p;
+	char buf1[256];
+	char buf2[256];
+
+	if ((p = getparentprocess(c)) == 0)
+		return 0;
+
+	snprintf(buf1, sizeof(buf1) - 1, "/proc/%u/exe", (unsigned)p);
+
+	if (readlink(buf1, buf2, sizeof(buf2) - 1) < 0) {
+		return 0;
+	}
+
+	if (strstr(buf2, "noswallow") != NULL) {
+		return 1;
+	}
+
+	return 0;
 }
 
 Client *

--- a/noswallow.c
+++ b/noswallow.c
@@ -1,0 +1,35 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+
+int main(int argc, char * const argv[]) {
+  int status;
+  pid_t pid;
+
+  if (argc < 2) {
+    fprintf(stderr, "Usage: %s <command> [args...]\n", argv[0]);
+    return  EXIT_FAILURE;
+  }
+
+  if ((pid = fork()) == 0) {
+    // Child process
+    execvp(argv[1], argv + 1);
+    fprintf(stderr, "Could not execute %s: %s\n", argv[1], strerror(errno));
+    return EXIT_FAILURE;
+  }
+  else if (pid < 0) {
+    // Error
+    fprintf(stderr, "Could not fork: %s\n", strerror(errno));
+    return EXIT_FAILURE;
+  }
+
+  if (waitpid(pid, &status, 0) == -1) {
+    fprintf(stderr, "Could not wait for child: %s\n", strerror(errno));
+    return EXIT_FAILURE;
+  }
+
+  return WIFEXITED(status) ? WEXITSTATUS(status) : EXIT_FAILURE;
+}


### PR DESCRIPTION
`noswallow` allows any process to be started from terminal without swallowing. The binary is installed into bin directory.